### PR TITLE
Box

### DIFF
--- a/src/Phake.php
+++ b/src/Phake.php
@@ -106,7 +106,7 @@ class Phake
      *
      * @return \Phake\IMock&T
      */
-    public static function mock($className, \Phake\Stubber\IAnswerContainer $defaultAnswer = null)
+    public static function mock($className, ?\Phake\Stubber\IAnswerContainer $defaultAnswer = null)
     {
         if (null === $defaultAnswer) {
             $answer = new \Phake\Stubber\Answers\SmartDefaultAnswer();
@@ -186,7 +186,7 @@ class Phake
      *
      * @return \Phake\Proxies\VerifierProxy
      */
-    public static function verify(\Phake\IMock $mock, \Phake\CallRecorder\IVerifierMode $mode = null)
+    public static function verify(\Phake\IMock $mock, ?\Phake\CallRecorder\IVerifierMode $mode = null)
     {
         if (is_null($mode)) {
             $mode = self::times(1);
@@ -207,7 +207,7 @@ class Phake
      *
      * @return \Phake\Proxies\VerifierProxy
      */
-    public static function verifyStatic(\Phake\IMock $mock, \Phake\CallRecorder\IVerifierMode $mode = null)
+    public static function verifyStatic(\Phake\IMock $mock, ?\Phake\CallRecorder\IVerifierMode $mode = null)
     {
         if (is_null($mode)) {
             $mode = self::times(1);

--- a/src/Phake/Annotation/MockInitializer.php
+++ b/src/Phake/Annotation/MockInitializer.php
@@ -84,7 +84,7 @@ class MockInitializer
         self::$defaultReader = $reader;
     }
 
-    public function __construct(IReader $reader = null)
+    public function __construct(?IReader $reader = null)
     {
         $this->reader = $reader ?: self::getDefaultReader();
     }

--- a/src/Phake/CallRecorder/CallExpectation.php
+++ b/src/Phake/CallRecorder/CallExpectation.php
@@ -81,7 +81,7 @@ class CallExpectation
     public function __construct(
         $object,
         $method,
-        \Phake\Matchers\IChainableArgumentMatcher $argumentMatcher = null,
+        ?\Phake\Matchers\IChainableArgumentMatcher $argumentMatcher,
         IVerifierMode $verificationMode
     ) {
         $this->object           = $object;

--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -73,7 +73,7 @@ class MockClass
      * @param ILoader $loader
      * @param IInstantiator $instantiator
      */
-    public function __construct(ILoader $loader = null, IInstantiator $instantiator = null)
+    public function __construct(?ILoader $loader = null, ?IInstantiator $instantiator = null)
     {
         $this->loader = $loader ?: new EvalLoader();
         $this->instantiator = $instantiator ?: new DoctrineInstantiator();
@@ -223,7 +223,7 @@ class {$newClassName} {$extends}
         \Phake\CallRecorder\Recorder $recorder,
         \Phake\Stubber\StubMapper $mapper,
         \Phake\Stubber\IAnswer $defaultAnswer,
-        array $constructorArgs = null
+        ?array $constructorArgs = null
     ) {
         $mockObject = $this->instantiator->instantiate($newClassName);
         assert($mockObject instanceof \Phake\IMock);

--- a/src/Phake/Exception/MethodMatcherException.php
+++ b/src/Phake/Exception/MethodMatcherException.php
@@ -61,7 +61,7 @@ class MethodMatcherException extends \Exception
      * @param string $message
      * @param \Exception $previous
      */
-    public function __construct($message = '', \Exception $previous = null)
+    public function __construct($message = '', ?\Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
         $this->argument = 0;

--- a/src/Phake/Facade.php
+++ b/src/Phake/Facade.php
@@ -90,7 +90,7 @@ class Facade
         ClassGenerator\MockClass $mockGenerator,
         CallRecorder\Recorder $callRecorder,
         Stubber\IAnswer $defaultAnswer,
-        array $constructorArgs = null
+        ?array $constructorArgs = null
     ) {
         $mockedClassList = (array) $mockedClassList;
 

--- a/src/Phake/Matchers/Factory.php
+++ b/src/Phake/Matchers/Factory.php
@@ -77,7 +77,7 @@ class Factory
      *
      * @return IChainableArgumentMatcher
      */
-    public function createMatcher($argument, IChainableArgumentMatcher $nextMatcher = null)
+    public function createMatcher($argument, ?IChainableArgumentMatcher $nextMatcher = null)
     {
         $return = null;
         if ($argument instanceof IChainableArgumentMatcher) {

--- a/src/Phake/Matchers/MethodMatcher.php
+++ b/src/Phake/Matchers/MethodMatcher.php
@@ -67,7 +67,7 @@ class MethodMatcher implements IMethodMatcher
     /**
      * @param string $expectedMethod
      */
-    public function __construct($expectedMethod, IChainableArgumentMatcher $argumentMatcherChain = null)
+    public function __construct($expectedMethod, ?IChainableArgumentMatcher $argumentMatcherChain = null)
     {
         $this->expectedMethod = $expectedMethod;
         $this->argumentMatcherChain = $argumentMatcherChain;

--- a/src/Phake/Proxies/CallVerifierProxy.php
+++ b/src/Phake/Proxies/CallVerifierProxy.php
@@ -92,7 +92,7 @@ class CallVerifierProxy
      *
      * @return array
      */
-    public function isCalledOn(\Phake\IMock $obj, \Phake\CallRecorder\IVerifierMode $verifierMode = null)
+    public function isCalledOn(\Phake\IMock $obj, ?\Phake\CallRecorder\IVerifierMode $verifierMode = null)
     {
         if (null === $verifierMode) {
             $verifierMode = new \Phake\CallRecorder\VerifierMode\Times(1);

--- a/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
+++ b/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
@@ -96,6 +96,8 @@ class SmartDefaultAnswer implements \Phake\Stubber\IAnswer
                         return \Phake::mock($typeName);
                     } elseif ($returnType->allowsNull()) {
                         return null;
+                    } elseif (interface_exists($typeName)) {
+                        return \Phake::mock($typeName);
                     }
                 }
         } elseif ($returnType instanceof \ReflectionIntersectionType) {

--- a/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
+++ b/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
@@ -92,7 +92,9 @@ class SmartDefaultAnswer implements \Phake\Stubber\IAnswer
                 case 'never':
                     return null;
                 default:
-                    if (class_exists($typeName)) {
+                    if (function_exists('enum_exists') && enum_exists($typeName)) {
+                        return $typeName::cases()[0];
+                    } elseif (class_exists($typeName)) {
                         return \Phake::mock($typeName);
                     } elseif ($returnType->allowsNull()) {
                         return null;

--- a/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
@@ -157,6 +157,20 @@ class SmartDefaultAnswerTest extends TestCase
         $this->assertInstanceOf(\Countable::class, $result);
     }
 
+    public function testEnumReturnType()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Intersection types are not supported in PHP versions prior to 8.1');
+        }
+
+        $context = new \PhakeTest_EnumType();
+        $cb = $this->answer->getAnswerCallback($context, 'enumReturn');
+
+        $result = $cb();
+        $this->assertInstanceOf(\SomeEnum::class, $result);
+
+    }
+
     public function testDNFTypeReturn()
     {
         if (PHP_VERSION_ID < 80200) {

--- a/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
@@ -114,6 +114,15 @@ class SmartDefaultAnswerTest extends TestCase
         $this->assertNull($cb());
     }
 
+    public function testInterfaceReturn()
+    {
+        $context = new \PhakeTest_ScalarTypes();
+        $cb = $this->answer->getAnswerCallback($context, 'interfaceReturn');
+
+        $this->assertInstanceOf('PhakeTest_MockedInterface', $cb());
+        $this->assertInstanceOf(\Phake\IMock::class, $cb());
+    }
+
     public function testSelfReturn()
     {
         $context = new \PhakeTest_ScalarTypes();

--- a/tests/PhakeClientTest.php
+++ b/tests/PhakeClientTest.php
@@ -13,7 +13,7 @@ class PhakeClientTest extends TestCase
         $refClass = new ReflectionClass('Phake');
         $clientProperty = $refClass->getProperty('client');
         $clientProperty->setAccessible(true);
-        $clientProperty->setValue(null);
+        $clientProperty->setValue(null, null);
     }
 
     public function testAutoDetectsPHPUnitClient()

--- a/tests/PhakeTest/EnumType.php
+++ b/tests/PhakeTest/EnumType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+enum SomeEnum: string
+{
+    case A = 'a';
+    case B = 'b';
+}
+
+class PhakeTest_EnumType
+{
+    public function enumReturn(): SomeEnum
+    {
+    }
+}

--- a/tests/PhakeTest/MockedInterface.php
+++ b/tests/PhakeTest/MockedInterface.php
@@ -50,11 +50,11 @@ interface PhakeTest_MockedInterface
 
     public function hinted(PhakeTest_MockedInterface $hinted);
 
-    public function hintedNull(PhakeTest_MockedInterface $hinted = null);
+    public function hintedNull(?PhakeTest_MockedInterface $hinted = null);
 
     public function hintedArray(array $hinted);
 
-    public function hintedArrayNull(array $hinted = null);
+    public function hintedArrayNull(?array $hinted = null);
 
     public function hintedArrayDefaulted(array $hinted = [1, 2, 3]);
 

--- a/tests/PhakeTest/MockedInterface2.php
+++ b/tests/PhakeTest/MockedInterface2.php
@@ -50,11 +50,11 @@ interface PhakeTest_MockedInterface2
 
     public function hinted(PhakeTest_MockedInterface $hinted);
 
-    public function hintedNull(PhakeTest_MockedInterface $hinted = null);
+    public function hintedNull(?PhakeTest_MockedInterface $hinted = null);
 
     public function hintedArray(array $hinted);
 
-    public function hintedArrayNull(array $hinted = null);
+    public function hintedArrayNull(?array $hinted = null);
 
     public function hintedArrayDefaulted(array $hinted = [1, 2, 3]);
 

--- a/tests/PhakeTest/ScalarTypes.php
+++ b/tests/PhakeTest/ScalarTypes.php
@@ -52,6 +52,10 @@ class PhakeTest_ScalarTypes
         return $a + $b;
     }
 
+    public function interfaceReturn(): PhakeTest_MockedInterface
+    {
+    }
+
     public function objectReturn(): PhakeTest_A
     {
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,7 +44,7 @@ declare(strict_types=1);
  * @link       http://www.digitalsandwich.com/
  */
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 /** @var $loader \Composer\Autoload\ClassLoader */
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
Only generate code containing parent:: references when parent exists
    (eg: mocked class is not an interface)
